### PR TITLE
add Mailpit for collecting outbound mail

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,19 @@ END
 # Install Mail::JMAPTalk and its pure-Perl dependencies
 RUN cpanm --notest --quiet Mail::JMAPTalk
 
+# Download the Mailpit binary (outbound-mail sink + web viewer). TARGETARCH is
+# set by buildx (amd64/arm64) and matches Mailpit's release asset names.
+ARG MAILPIT_VERSION=v1.30.5
+ARG TARGETARCH
+RUN <<END
+set -e
+cd /tmp
+wget -qO mailpit.tar.gz \
+    "https://github.com/axllent/mailpit/releases/download/${MAILPIT_VERSION}/mailpit-linux-${TARGETARCH:-amd64}.tar.gz"
+tar xzf mailpit.tar.gz mailpit
+install -m 0755 mailpit /usr/local/bin/mailpit
+END
+
 ########################################
 # Stage 2: Slim runtime image
 ########################################
@@ -89,6 +102,9 @@ COPY --from=builder /usr/local/cyruslibs /usr/local/cyruslibs
 # Copy fakesaslauthd
 COPY --from=builder /srv/cyrus-imapd/cassandane/utils/fakesaslauthd /usr/cyrus/bin/fakesaslauthd
 
+# Copy the Mailpit binary
+COPY --from=builder /usr/local/bin/mailpit /usr/local/bin/mailpit
+
 # Tie::DataUUID: pure Perl, not packaged for Debian, needed by Cyrus::AccountSync
 COPY --from=builder /usr/local/share/perl/5.36.0/Tie/DataUUID.pm /tmp/DataUUID.pm
 
@@ -136,8 +152,10 @@ EXPOSE 8110
 EXPOSE 8143
 EXPOSE 4190
 EXPOSE 8587
+EXPOSE 8025
 
 ENV SERVERNAME=cyrus-docker-test-server
 ENV DEFAULTDOMAIN=example.com
+ENV MAILPITPORT=8025
 
 CMD [ "/srv/testserver/start-server" ]

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ build:
 
 run: stop
 	docker run --platform $(PLATFORM) -d --name $(CONTAINER_NAME) \
-	  -p 8080:8080 -p 8143:8143 -p 8110:8110 -p 8024:8024 -p 8001:8001 -p 4190:4190 -p 8587:8587 \
+	  -p 8080:8080 -p 8143:8143 -p 8110:8110 -p 8024:8024 -p 8001:8001 -p 4190:4190 -p 8587:8587 -p 8025:8025 \
 	  $(IMAGE_NAME):$(TAG)
 	@echo "Waiting for container to be ready..."
 	@for i in $$(seq 1 $(STARTUP_TIMEOUT)); do \

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ into a slim `debian:bookworm-slim` base, producing a much smaller image.
 | LMTP                             | 8024 |
 | Sieve (ManageSieve)              | 4190 |
 | SMTP Submission                  | 8587 |
+| Mailpit (outbound mail capture)  | 8025 |
 | Management web UI / API          | 8001 |
 
 All ports are configurable via environment variables (see below).
@@ -58,6 +59,8 @@ The server is configured for a modern IMAP layout:
 | `LMTPPORT`          | `8024`                     | LMTP port                                        |
 | `SIEVEPORT`         | `4190`                     | ManageSieve port                                 |
 | `SMTPPORT`          | `8587`                     | SMTP submission port                             |
+| `MAILPITPORT`       | `8025`                     | Mailpit web UI port                              |
+| `RELAYHOST`         | `[127.0.0.1]:1025`         | Postfix relay target for outbound mail           |
 | `SKIP_CREATE_USERS` | (unset)                    | If set, skip creating default users (user1–user5)|
 
 # Running
@@ -66,7 +69,7 @@ To run with all ports forwarded (create `env.txt` for any custom variables):
 
 ```
 docker run -it --env-file=env.txt \
-  -p 8080:8080 -p 8143:8143 -p 8110:8110 -p 8024:8024 -p 8001:8001 -p 4190:4190 -p 8587:8587 \
+  -p 8080:8080 -p 8143:8143 -p 8110:8110 -p 8024:8024 -p 8001:8001 -p 4190:4190 -p 8587:8587 -p 8025:8025 \
   ghcr.io/cyrusimap/cyrus-docker-test-server:latest
 ```
 
@@ -256,6 +259,23 @@ curl smtp://localhost:8024 --mail-from sender@example.com \
 ```
 telnet localhost 4190
 ```
+
+# Outbound mail (Mailpit)
+
+Outbound mail — anything Cyrus emits (JMAP `EmailSubmission`, Sieve `redirect`,
+iMIP invites) or anything sent through the SMTP submission port — is handed to
+Postfix. Mail addressed to a local `example.com` user is delivered into that
+user's Cyrus mailbox; mail to any other domain is **captured by
+[Mailpit](https://github.com/axllent/mailpit)** rather than being sent to the
+real internet.
+
+Browse captured messages at http://localhost:8025/ (or via Mailpit's REST API
+under `/api/v1/`). This lets you inspect exactly what a client submitted without
+anything leaking outbound.
+
+To relay outbound mail to a real server instead of capturing it, set the
+`RELAYHOST` environment variable (e.g. `RELAYHOST=[smtp.example.net]:587`, with
+`RELAYAUTH=user:pass` for authentication).
 
 # Caveats
 

--- a/test.sh
+++ b/test.sh
@@ -13,6 +13,7 @@ LMTP_PORT=${TEST_LMTPPORT:-8024}
 SIEVE_PORT=${TEST_SIEVEPORT:-4190}
 WEB_PORT=${TEST_WEBPORT:-8001}
 SMTP_PORT=${TEST_SMTPPORT:-8587}
+MAILPIT_PORT=${TEST_MAILPITPORT:-8025}
 
 PASS=0
 FAIL=0
@@ -510,6 +511,68 @@ if echo "$SMTP_AUTH_OUT" | grep -q "^235"; then
   pass "SMTP AUTH PLAIN succeeds with any password (fakesaslauthd)"
 else
   fail "SMTP AUTH PLAIN succeeds with any password (fakesaslauthd)"
+fi
+
+echo ""
+
+# -----------------------------------------------
+echo "[Mailpit]"
+# -----------------------------------------------
+
+check_output "Mailpit API responds" "Version" \
+  curl -sf "http://$HOST:$MAILPIT_PORT/api/v1/info"
+
+# Submit a message to an external recipient; Postfix should relay it to the
+# Mailpit sink (local example.com mail would instead be delivered to a mailbox).
+MAILPIT_SUBJECT="mailpit-capture-$$"
+perl -e '
+  use IO::Socket::INET;
+  use MIME::Base64;
+  my $subject = shift;
+  my $creds = encode_base64("\x00user1\x00anypassword", "");
+  my $sock = IO::Socket::INET->new(
+    PeerAddr => "'"$HOST"'", PeerPort => '"$SMTP_PORT"',
+    Proto    => "tcp",
+    Timeout  => 10,
+  ) or die "connect: $!";
+  $sock->autoflush(1);
+  sub rd {
+    my $buf = "";
+    while (my $line = <$sock>) {
+      $buf .= $line;
+      last if $line =~ /^\d{3} /;
+    }
+    return $buf;
+  }
+  rd();
+  print $sock "EHLO test\r\n"; rd();
+  print $sock "AUTH PLAIN $creds\r\n"; rd();
+  print $sock "MAIL FROM:<user1\@example.com>\r\n"; rd();
+  print $sock "RCPT TO:<sink\@external.invalid>\r\n"; rd();
+  print $sock "DATA\r\n"; rd();
+  print $sock "From: user1\@example.com\r\n";
+  print $sock "To: sink\@external.invalid\r\n";
+  print $sock "Subject: $subject\r\n";
+  print $sock "\r\nThis message should be captured by Mailpit.\r\n";
+  print $sock ".\r\n"; rd();
+  print $sock "QUIT\r\n"; rd();
+  close $sock;
+' "$MAILPIT_SUBJECT" >/dev/null 2>&1
+
+# Postfix relays asynchronously, so poll Mailpit for the message.
+CAPTURED=""
+for i in $(seq 1 15); do
+  if curl -sf "http://$HOST:$MAILPIT_PORT/api/v1/search?query=$MAILPIT_SUBJECT" \
+       | grep -q "$MAILPIT_SUBJECT"; then
+    CAPTURED=1
+    break
+  fi
+  sleep 1
+done
+if [ -n "$CAPTURED" ]; then
+  pass "Outbound mail to external domain captured by Mailpit"
+else
+  fail "Outbound mail to external domain captured by Mailpit"
 fi
 
 echo ""

--- a/testserver/start-server
+++ b/testserver/start-server
@@ -8,11 +8,22 @@ export LMTPPORT=${LMTPPORT:-8024}
 export SIEVEPORT=${SIEVEPORT:-4190}
 export WEBPORT=${WEBPORT:-8001}
 export SMTPPORT=${SMTPPORT:-8587}
+export MAILPITPORT=${MAILPITPORT:-8025}
+export MAILPITSMTP=${MAILPITSMTP:-1025}
+
+# By default, capture outbound mail in Mailpit instead of relaying it to the
+# real internet. Setting RELAYHOST explicitly overrides this with a real relay.
+# -- claude, 2026-07-21
+export RELAYHOST=${RELAYHOST:-[127.0.0.1]:${MAILPITSMTP}}
 
 # start syslog
 if [ ! -e '/run/rsyslog.pid' ]; then
   /usr/sbin/rsyslogd
 fi
+
+# start Mailpit: SMTP sink on loopback (Postfix relays to it), web UI exposed
+mailpit --smtp 127.0.0.1:${MAILPITSMTP} --listen 0.0.0.0:${MAILPITPORT} \
+  >/var/log/mailpit.log 2>&1 &
 
 # set up Postfix
 if [ "X$RELAYAUTH" != "X" ]; then

--- a/testserver/templates/index.html.tt
+++ b/testserver/templates/index.html.tt
@@ -31,6 +31,10 @@
       <div class="label">SMTP Submission</div>
       <div class="value">Port [% smtp_port %]</div>
     </div>
+    <div class="info-item">
+      <div class="label">Mailpit (outbound mail)</div>
+      <div class="value"><a href="http://localhost:[% mailpit_port %]/">Port [% mailpit_port %]</a></div>
+    </div>
   </div>
 </div>
 
@@ -53,6 +57,12 @@
 
   <h3>SMTP Submission</h3>
   <pre>openssl s_client -connect localhost:[% smtp_port %] -starttls smtp</pre>
+
+  <h3>Outbound mail</h3>
+  <p>Mail to external domains is captured in
+  <a href="http://localhost:[% mailpit_port %]/">Mailpit</a> for inspection;
+  mail to <code>example.com</code> users is still delivered to their Cyrus
+  mailboxes.</p>
 </div>
 
 <div class="card">

--- a/testserver/templates/layout.html.tt
+++ b/testserver/templates/layout.html.tt
@@ -56,6 +56,7 @@
       <span class="brand">Cyrus Test Server</span>
       <a href="/">Home</a>
       <a href="/ui/users">Users</a>
+      <a href="http://localhost:[% mailpit_port %]/">Mailpit</a>
     </div>
   </nav>
   <div class="container">

--- a/testserver/webserver.pl
+++ b/testserver/webserver.pl
@@ -30,18 +30,20 @@ my $IMAP_PORT  = $ENV{IMAPPORT}  // 8143;
 my $POP3_PORT  = $ENV{POP3PORT}  // 8110;
 my $HTTP_PORT  = $ENV{HTTPPORT}  // 8080;
 my $LMTP_PORT  = $ENV{LMTPPORT}  // 8024;
-my $SIEVE_PORT = $ENV{SIEVEPORT} // 4190;
-my $SMTP_PORT  = $ENV{SMTPPORT}  // 8587;
+my $SIEVE_PORT   = $ENV{SIEVEPORT}  // 4190;
+my $SMTP_PORT    = $ENV{SMTPPORT}   // 8587;
+my $MAILPIT_PORT = $ENV{MAILPITPORT} // 8025;
 
 sub _common_vars {
   return (
-    web_port   => $WEB_PORT,
-    imap_port  => $IMAP_PORT,
-    pop3_port  => $POP3_PORT,
-    http_port  => $HTTP_PORT,
-    lmtp_port  => $LMTP_PORT,
-    sieve_port => $SIEVE_PORT,
-    smtp_port  => $SMTP_PORT,
+    web_port     => $WEB_PORT,
+    imap_port    => $IMAP_PORT,
+    pop3_port    => $POP3_PORT,
+    http_port    => $HTTP_PORT,
+    lmtp_port    => $LMTP_PORT,
+    sieve_port   => $SIEVE_PORT,
+    smtp_port    => $SMTP_PORT,
+    mailpit_port => $MAILPIT_PORT,
   );
 }
 


### PR DESCRIPTION
The test server isn't really a great way to send mail to the internet, and I'd like to discourage it.  More than that, I'd like to make it easy for a developer to see what mail would have been sent.  Mailpit is a tool for this kind of thing.  With this branch, we add Mailpit to the image, then configure postfix to relay non-example.com mail into Mailpit.  The Mailpit web UI lets you review all the mail, its headers, and so on.